### PR TITLE
Fixed a startup issue in sample page

### DIFF
--- a/pages/sample-page.jsx
+++ b/pages/sample-page.jsx
@@ -12,7 +12,7 @@ const SamplePage = ({ elements }) => {
 
 export const getStaticProps = async () => {
     const res = await fetch(process.env.NEXT_PUBLIC_WP_URL + "/wp-json/wp/v2/pages?slug=sample-page&acf_format=standard").then(r => r.json())
-    const elements = res[0]?.acf?.elements
+    const elements = res[0]?.acf?.elements || null
     return {
         props: {
             elements: elements


### PR DESCRIPTION
# Fix to a startup issue
## Sample page caused an issue in startup when dealing with static assets

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Startup issue
  1. pages/sample-page.jsx
     * when assets are missing, use null value